### PR TITLE
spelling correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Modification of data is supported too. According to the OSM license every modifi
     api.save(node, changeset)
     api.close_changeset(changeset)
 
-Yeah, i can hear you sayin: 'Seriously, do i have to provide username and password? Is that secure?' Providing username and password is prone to some security issues, especially because the OSM API does not provide an SSL service. But wait, there is some more in store for you: [OAuth](http://oauth.net/) It's much more secure for the user and your OSM app. But it comes with a price: You have to register an application on http://www.openstreetmap.org. After you have your app registered you get an app key and secret. Keep it in a save place.
+Yeah, i can hear you sayin: 'Seriously, do i have to provide username and password? Is that secure?' Providing username and password is prone to some security issues, especially because the OSM API does not provide an SSL service. But wait, there is some more in store for you: [OAuth](http://oauth.net/) It's much more secure for the user and your OSM app. But it comes with a price: You have to register an application on http://www.openstreetmap.org. After you have your app registered you get an app key and secret. Keep it in a safe place.
 
     consumer = OAuth::Consumer.new( 'osm_app_key', 'osm_app_secret',
                                     :site => 'http://www.openstreetmap.org')


### PR DESCRIPTION
Trivial spelling correction - "save place" -> "safe place".
